### PR TITLE
Just fix footer twitter link that doesn't work anymore

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -6,7 +6,7 @@
         <a class="facebook" href="http://www.facebook.com/MovimentoSemTerra">Facebook</a>
       </li>
       <li>
-        <a class="twitter" href="http://twitter.com/#!/MST_Oficial">Twitter</a>
+        <a class="twitter" href="http://twitter.com/MST_Oficial">Twitter</a>
       </li>
       <li>
         <a class="rss" href="{{ site.url }}/rss.xml">RSS</a>


### PR DESCRIPTION
Before: http://twitter.com/#!/MST_Oficial
Now: http://twitter.com/MST_Oficial